### PR TITLE
Include sst_dump with the node image

### DIFF
--- a/node-1.12/Dockerfile.ubuntu
+++ b/node-1.12/Dockerfile.ubuntu
@@ -71,7 +71,9 @@ RUN mkdir rocksdb && \
     cd rocksdb && \
     tar xzf rocksdb.tar.gz && \
     cd ./* && \
-    CXXFLAGS="-flto -Os -s" PORTABLE=1 make install-shared && \
+    CXXFLAGS="-flto -Os -s" PORTABLE=1 DEBUG_LEVEL=0 make install-shared && \
+    CXXFLAGS="-flto -Os -s" PORTABLE=1 DEBUG_LEVEL=0 make sst_dump && \
+    cp -a sst_dump "$HOME/.local/bin" && \
     cd $HOME && \
     cp -a /usr/local/lib/librocksdb.so* "$HOME/.local/lib" && \
     rm -rf rocksdb


### PR DESCRIPTION
- For use in analyzing `RocksDB` database files.
- Build `RocksDB` components in release mode.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>