### PR TITLE
Update next image - rust, indy-sdk, indy-vdr, shared-rs, aries-askar to latest working versions

### DIFF
--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 # set to --release for smaller, optimized library
-ARG indy_build_flags=
+ARG indy_build_flags=--release
 
 # overridden by the build script
 ARG indy_sdk_url=https://codeload.github.com/hyperledger/indy-sdk/tar.gz/ae9f8a252bb99e8b80c6d34c6c985fd95abfadef

--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.45-slim-buster as builder
+FROM rust:1.63-slim-buster as builder
 
 ARG user=indy
 ENV HOME="/home/$user"
@@ -34,10 +34,10 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 # set to --release for smaller, optimized library
-ARG indy_build_flags=--release
+ARG indy_build_flags=
 
 # overridden by the build script
-ARG indy_sdk_url=https://codeload.github.com/bcgov/indy-sdk/tar.gz/574ca3a881d188c3fd7400d27acbe5edc4c7f666
+ARG indy_sdk_url=https://codeload.github.com/hyperledger/indy-sdk/tar.gz/ae9f8a252bb99e8b80c6d34c6c985fd95abfadef
 
 # make local libs and binaries accessible
 ENV PATH="$HOME/.local/bin:$PATH"
@@ -78,7 +78,7 @@ WORKDIR $HOME
 RUN rm -rf indy-sdk
 
 
-ARG indy_vdr_url=https://codeload.github.com/andrewwhitehead/indy-vdr/tar.gz/aedd57ed5ca6c27c78bab946dbb7843048be750f
+ARG indy_vdr_url=https://codeload.github.com/hyperledger/indy-vdr/tar.gz/36b2bd9f00126b4cbaf2f033e0d4835d1dbae4f2
 
 # Download and extract indy-vdr
 RUN mkdir indy-vdr && \
@@ -104,7 +104,7 @@ WORKDIR $HOME
 RUN rm -rf indy-vdr
 
 
-ARG indy_shared_url=https://codeload.github.com/bcgov/indy-shared-rs/tar.gz/7a8e49848a08bbda29e128b1913cc757076529b1
+ARG indy_shared_url=https://codeload.github.com/hyperledger/indy-shared-rs/tar.gz/68a495d53211882feb10fc55875e9c0e8921958a
 
 # Download and extract indy-credx
 RUN mkdir indy-shared-rs && \
@@ -128,7 +128,7 @@ WORKDIR $HOME
 RUN rm -rf indy-shared-rs
 
 
-ARG aries_askar_url=https://codeload.github.com/andrewwhitehead/aries-askar/tar.gz/0da224cccfcd20e074b3aa655bddaef86d95d988
+ARG aries_askar_url=https://codeload.github.com/hyperledger/aries-askar/tar.gz/ceb294006fc76c9e7976bd2005e0d6c740c21afe
 
 # Download and extract aries-askar
 RUN mkdir aries-askar && \


### PR DESCRIPTION
Creating this PR to update the Rust base image and dependencies of the next-image to latest versions.