### PR TITLE
Fix build issues

### DIFF
--- a/node-1.12/Dockerfile.ubuntu
+++ b/node-1.12/Dockerfile.ubuntu
@@ -40,7 +40,7 @@ ARG nacl_lib_ver=1.0.16
 
 # Build and install libsodium library
 RUN curl -o libsodium-${nacl_lib_ver}.tar.gz \
-        "https://download.libsodium.org/libsodium/releases/old/libsodium-${nacl_lib_ver}.tar.gz" && \
+        "https://download.libsodium.org/libsodium/releases/old/unsupported/libsodium-${nacl_lib_ver}.tar.gz" && \
     tar xzvf libsodium-${nacl_lib_ver}.tar.gz && \
     cd libsodium-${nacl_lib_ver} && \
     CFLAGS="-Os" ./configure && \

--- a/node-1.12/requirements.txt
+++ b/node-1.12/requirements.txt
@@ -4,7 +4,7 @@ aiosqlite~=0.13.0
 base58~=1.0.0
 cchardet~=2.1.0
 rlp~=0.6.0
-cython
+cython==0.29.36
 python-rocksdb==0.7.0
 indy-node==1.12.6
 git+https://github.com/hyperledger/indy-plenum.git@0bbf5c84fc11290cee4272649eb8288de0fa756d#egg=indy-plenum


### PR DESCRIPTION
- Updates needed to rebuild and republish `bcgovimages/von-image:node-1.12-6` complete with the `sst_dump` cli tool.